### PR TITLE
#963804 SASS compiler generates too much assets

### DIFF
--- a/ExtendedScssc.php
+++ b/ExtendedScssc.php
@@ -6,15 +6,86 @@
  * @author Artem Frolov <artem@frolov.net>
  * @link https://github.com/artem-frolov/yii-sass
  */
-class ExtendedScssc extends \ScssPhp\ScssPhp\Compiler
-{
-    /**
+class ExtendedScssc extends Sass {
+	protected $parsedFiles = [];
+
+
+	public function __construct() {
+		parent::__construct();
+
+		$this->setImporter([$this, 'import']);
+	}
+
+
+	/*
+	 * imp_path
+	 * abs_path
+	 * source
+	 * srcmap
+	 */
+	public function import($arg) {
+		// FIXME absoluut import path nodig
+		if (!in_array($arg, $this->parsedFiles)) {
+			$this->parsedFiles[] = $arg;
+		}
+	}
+
+
+	/**
      * Get list of current import paths
-     *
      * @return array
      */
-    public function getImportPaths()
-    {
-        return $this->importPaths;
+    public function getImportPaths() : array {
+        return explode(':', $this->getIncludePath());
     }
+
+
+	/**
+	 * @param string $path
+	 * @return bool
+	 */
+	public function addImportPath(string $path) : bool {
+		$paths = $this->getImportPaths();
+
+        $preparedPath = YiiBase::getPathOfAlias($path);
+        if ($preparedPath === false || empty($preparedPath)) {
+            $preparedPath = $path;
+        }
+
+		if (!in_array($preparedPath, $paths)) {
+			$paths[] = $preparedPath;
+		}
+
+		return true;
+    }
+
+
+	/**
+	 * @param string $path
+	 * @return bool
+	 */
+	public function addImportPaths(array $paths) : bool {
+		$success = true;
+		foreach ($paths as $path) {
+			$success &= $this->addImportPath($path);
+		}
+
+		return $success;
+    }
+
+	/**
+	 * @param array $paths
+	 */
+	public function setImportPaths(array $paths) {
+        $this->setIncludePath(implode(':', $paths));
+    }
+
+
+	/**
+	 * @return array
+	 */
+	public function getParsedFiles() {
+		return $this->parsedFiles;
+    }
+
 }

--- a/ExtendedScssc.php
+++ b/ExtendedScssc.php
@@ -6,7 +6,7 @@
  * @author Artem Frolov <artem@frolov.net>
  * @link https://github.com/artem-frolov/yii-sass
  */
-class ExtendedScssc extends Leafo\ScssPhp\Compiler
+class ExtendedScssc extends \ScssPhp\ScssPhp\Compiler
 {
     /**
      * Get list of current import paths

--- a/ExtendedScssc.php
+++ b/ExtendedScssc.php
@@ -6,15 +6,108 @@
  * @author Artem Frolov <artem@frolov.net>
  * @link https://github.com/artem-frolov/yii-sass
  */
-class ExtendedScssc extends \ScssPhp\ScssPhp\Compiler
-{
-    /**
+class ExtendedScssc extends Sass {
+	protected $parsedFiles = [];
+
+
+	public function __construct() {
+		parent::__construct();
+
+		parent::setFunctions([
+			'baseUrl' => function() {
+				EO::app()->getBaseUrl(true);
+			},
+			'relBaseUrl' => function() {
+				EO::app()->getBaseUrl(false);
+			},
+			'basePath' => function() {
+				EO::app()->getBasePath();
+			},
+		]);
+
+        if (!defined('YII_DEBUG') || !YII_DEBUG) {
+        	$this->setEmbed(true);
+        }
+
+//		parent::setIncludePath(YiiBase::getPathOfAlias('@webroot'));
+		parent::setIncludePath($_SERVER['DOCUMENT_ROOT']);
+
+		$this->setImporter([$this, 'import']);
+	}
+
+
+	/*
+	 * imp_path
+	 * abs_path
+	 * source
+	 * srcmap
+	 */
+	public function import($arg) {
+		if (!array_key_exists($arg, $this->parsedFiles)) {
+			$this->parsedFiles[$arg] = (new DateTime)->getTimestamp();
+		}
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getParsedFiles() {
+		return $this->parsedFiles;
+    }
+
+
+	/**
      * Get list of current import paths
-     *
      * @return array
      */
-    public function getImportPaths()
-    {
-        return $this->importPaths;
+    public function getImportPaths() : array {
+        return explode(':', $this->getIncludePath());
     }
+
+
+	/**
+	 * @param string $path
+	 * @return bool
+	 */
+	public function addImportPath(string $path) : bool {
+		$paths = $this->getImportPaths();
+
+        $preparedPath = YiiBase::getPathOfAlias($path);
+        if ($preparedPath === false || empty($preparedPath)) {
+            $preparedPath = $path;
+        }
+
+		if (!in_array($preparedPath, $paths)) {
+			$paths[] = $preparedPath;
+		}
+
+		return true;
+    }
+
+
+	/**
+	 * @param string $path
+	 * @return bool
+	 */
+	public function addImportPaths(array $paths) : bool {
+		$success = true;
+		foreach ($paths as $path) {
+			$success &= $this->addImportPath($path);
+		}
+
+		return $success;
+    }
+
+	/**
+	 * @param array $paths
+	 */
+	public function setImportPaths(array $paths) {
+        $this->setIncludePath(implode(':', $paths));
+    }
+
+
+	public function setIncludePath($path) {
+		parent::setIncludePath($path);
+	}
+
 }

--- a/ExtendedScssc.php
+++ b/ExtendedScssc.php
@@ -29,6 +29,7 @@ class ExtendedScssc extends Sass {
         	$this->setEmbed(true);
         }
 
+//		parent::setIncludePath(YiiBase::getPathOfAlias('@webroot'));
 		parent::setIncludePath($_SERVER['DOCUMENT_ROOT']);
 
 		$this->setImporter([$this, 'import']);
@@ -45,8 +46,6 @@ class ExtendedScssc extends Sass {
 		if (!in_array($arg, $this->parsedFiles)) {
 			$this->parsedFiles[] = $arg;
 		}
-
-		return $this->parsedFiles;
 	}
 
 

--- a/ExtendedScssc.php
+++ b/ExtendedScssc.php
@@ -53,16 +53,16 @@ class ExtendedScssc extends Sass {
 	 */
 	public function getParsedFiles() {
 		return $this->parsedFiles;
-  }
+	}
 
 
 	/**
      * Get list of current import paths
      * @return array
      */
-  public function getImportPaths() : array {
-        return explode(':', $this->getIncludePath());
-  }
+	public function getImportPaths() : array {
+	    return explode(':', $this->getIncludePath());
+	}
 
 
 	/**
@@ -80,6 +80,8 @@ class ExtendedScssc extends Sass {
 		if (!in_array($preparedPath, $paths)) {
 			$paths[] = $preparedPath;
 		}
+
+		$this->setIncludePath(implode(':', $paths));
 
 		return true;
     }

--- a/ExtendedScssc.php
+++ b/ExtendedScssc.php
@@ -13,6 +13,24 @@ class ExtendedScssc extends Sass {
 	public function __construct() {
 		parent::__construct();
 
+		parent::setFunctions([
+			'baseUrl' => function() {
+				EO::app()->getBaseUrl(true);
+			},
+			'relBaseUrl' => function() {
+				EO::app()->getBaseUrl(false);
+			},
+			'basePath' => function() {
+				EO::app()->getBasePath();
+			},
+		]);
+
+        if (!defined('YII_DEBUG') || !YII_DEBUG) {
+        	$this->setEmbed(true);
+        }
+
+		parent::setIncludePath($_SERVER['DOCUMENT_ROOT']);
+
 		$this->setImporter([$this, 'import']);
 	}
 
@@ -24,10 +42,11 @@ class ExtendedScssc extends Sass {
 	 * srcmap
 	 */
 	public function import($arg) {
-		// FIXME absoluut import path nodig
 		if (!in_array($arg, $this->parsedFiles)) {
 			$this->parsedFiles[] = $arg;
 		}
+
+		return $this->parsedFiles;
 	}
 
 
@@ -79,6 +98,11 @@ class ExtendedScssc extends Sass {
 	public function setImportPaths(array $paths) {
         $this->setIncludePath(implode(':', $paths));
     }
+
+
+	public function setIncludePath($path) {
+		parent::setIncludePath($path);
+	}
 
 
 	/**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-Sass (SCSS) and Compass support for the Yii framework
+Sass (SCSS) support for the Yii framework
 ========
-yii-sass extension implements Sass and Compass support: compilation on-the-fly,
+yii-sass extension implements Sass support: compilation on-the-fly,
 publishing, registration in views.
 
 [![Build Status](https://travis-ci.org/artem-frolov/yii-sass.svg?branch=master)](https://travis-ci.org/artem-frolov/yii-sass)
@@ -16,19 +16,11 @@ It allows you to use variables, nested rules, mixins, inline imports, and more,
 all with a fully CSS-compatible syntax. Sass helps keep large stylesheets
 well-organized, and get small stylesheets up and running quickly.
 
-**[Compass](http://compass-style.org/reference/compass/ "Compass framework reference")**
-is an open-source CSS authoring framework which uses
-the Sass stylesheet language to make writing stylesheets powerful and easy.
-
-This extension caches compiled CSS code and prevents recompilation if there is no need in it.
-
 Requirements
 --------
 * PHP >= 5.4
 * Yii 1.0 or 1.1
 * [scssphp compiler](http://leafo.net/scssphp/)
-* [scssphp-compass library](https://github.com/leafo/scssphp-compass) -
-*only if Compass support is needed*
 
 Installation
 --------
@@ -62,10 +54,7 @@ or manually by downloading required files.
             'class' => 'vendor.artem-frolov.yii-sass.SassHandler',
             
             // Use the following if you use Composer's autoloader and Yii >= 1.1.15
-            //'class' => 'SassHandler',
-            
-            // Enable Compass support, defaults to false
-            'enableCompass' => true,
+            //'class' => 'SassHandler',            
         ),
         ...
     ),
@@ -77,9 +66,6 @@ or manually by downloading required files.
     will look like "protected/extensions/yii-sass/SassHandler.php"
 2.  [Download scssphp compiler](https://github.com/leafo/scssphp/archive/master.zip "Download scssphp compiler from Github")  
     Put files to the "protected/vendor/scssphp" directory
-3.  [Download scssphp-compass library](https://github.com/leafo/scssphp-compass/archive/master.zip "Download scssphp-compass library from Github")  
-    *Skip this step if you don't need Compass support*  
-    Put files to the "protected/vendor/scssphp-compass" directory
 4.  Update your application's configuration *(e.g. protected/config/main.php)* like this:
     
     ```php
@@ -91,13 +77,6 @@ or manually by downloading required files.
             
             // Path and filename of scss.inc.php
             'compilerPath' => __DIR__ . '/../vendor/scssphp/scss.inc.php',
-            
-            // Path and filename of compass.inc.php
-            // Required only if Compass support is needed
-            'compassPath' => __DIR__ . '/../vendor/scssphp-compass/compass.inc.php',
-            
-            // Enable Compass support, defaults to false
-            'enableCompass' => true,
         ),
         ...
     ),
@@ -126,11 +105,6 @@ All options below are optional except the "class" item.
         // Path and filename of scss.inc.php
         // Defaults to the relative location in Composer's vendor directory
         'compilerPath' => __DIR__ . "/../../../vendor/leafo/scssphp/scss.inc.php",
-        
-        // Path and filename of compass.inc.php
-        // Required only if Compass support is needed
-        // Defaults to the relative location in Composer's vendor directory
-        'compassPath' => __DIR__ . '/../../../vendor/leafo/scssphp-compass/compass.inc.php',
 
         // Path for cache files. Will be used if Yii caching is not enabled.
         // Will be chmod'ed to become writable,
@@ -138,12 +112,7 @@ All options below are optional except the "class" item.
         // Yii aliases can be used.
         // Defaults to 'application.runtime.sass-cache'
         'cachePath' => 'application.runtime.sass-cache',
-        
-        // Enable Compass support.
-        // Automatically add required import paths and functions.
-        // Defaults to false
-        'enableCompass' => false,
-        
+                
         // Path to a directory with compiled CSS files.
         // Will be created automatically if it doesn't exist.
         // Will be chmod'ed to become writable,
@@ -391,7 +360,6 @@ Changelog
     - Add new formatting type ``SassHandler::OUTPUT_FORMATTING_CRUNCHED`` which
       can be used with ``compilerOutputFormatting`` parameter *(alexdevid)*
     - Add unit tests to check integration with ``scssphp`` compiler
-      and with ``scssphp-compass`` library
     - Fix a bug: ``$hashByName=true`` argument wasn't properly passed to the Yii's asset manager
     - Minor fixes and improvements
 

--- a/SassHandler.php
+++ b/SassHandler.php
@@ -353,7 +353,7 @@ class SassHandler extends CApplicationComponent
     public function compile($sourcePath) {
         if ($this->autoAddCurrentDirectoryAsImportPath) {
             $this->compiler->addImportPath(dirname($sourcePath));
-            $this->compiler->addImportPath(YiiBase::getPathOfAlias('@webroot'));
+//            $this->compiler->addImportPath(YiiBase::getPathOfAlias('@webroot'));
         }
 
         $sourceCode = file_get_contents($sourcePath);

--- a/SassHandler.php
+++ b/SassHandler.php
@@ -350,11 +350,10 @@ class SassHandler extends CApplicationComponent
      * @throws CException
      * @return string Compiled CSS code
      */
-    public function compile($sourcePath)
-    {
+    public function compile($sourcePath) {
         if ($this->autoAddCurrentDirectoryAsImportPath) {
-//            $originalImportPaths = $this->compiler->getImportPaths();
             $this->compiler->addImportPath(dirname($sourcePath));
+            $this->compiler->addImportPath(YiiBase::getPathOfAlias('@webroot'));
         }
 
         $sourceCode = file_get_contents($sourcePath);
@@ -364,13 +363,11 @@ class SassHandler extends CApplicationComponent
             );
         }
 
-        $compiledCssCode = $this->compiler->compile($sourceCode);
+        $compiledCssCode = $this->compiler->compile(ltrim($sourceCode));
 
-		$compiledCssCode 		= (new Autoprefixer($compiledCssCode))->compile();
-
-//        if ($this->autoAddCurrentDirectoryAsImportPath) {
-//            $this->compiler->setImportPaths($originalImportPaths);
-//        }
+        if (!defined('YII_DEBUG') || !YII_DEBUG) {
+			$compiledCssCode 		= (new Autoprefixer($compiledCssCode))->compile();
+        }
 
         return $compiledCssCode;
     }

--- a/SassHandler.php
+++ b/SassHandler.php
@@ -530,13 +530,13 @@ class SassHandler extends CApplicationComponent
     {
         $formatters = array(
             self::OUTPUT_FORMATTING_NESTED
-                => 'Leafo\ScssPhp\Formatter\Nested',
+                => 'ScssPhp\ScssPhp\Formatter\Nested',
             self::OUTPUT_FORMATTING_COMPRESSED
-                => 'Leafo\ScssPhp\Formatter\Compressed',
+                => 'ScssPhp\ScssPhp\Formatter\Compressed',
             self::OUTPUT_FORMATTING_EXPANDED
-                => 'Leafo\ScssPhp\Formatter\Expanded',
+                => 'ScssPhp\ScssPhp\Formatter\Expanded',
             self::OUTPUT_FORMATTING_CRUNCHED
-                => 'Leafo\ScssPhp\Formatter\Crunched',
+                => 'ScssPhp\ScssPhp\Formatter\Crunched',
         );
         if (isset($formatters[$this->compilerOutputFormatting])) {
             $compiler->setFormatter(

--- a/SassHandler.php
+++ b/SassHandler.php
@@ -31,7 +31,7 @@ class SassHandler extends CApplicationComponent
      * Path and filename of scss.inc.php
      *
      * Defaults to the relative location in Composer's vendor directory:
-     * __DIR__ . "/../../leafo/scssphp/scss.inc.php"
+     * __DIR__ . "/../../scssphp/scssphp/scss.inc.php"
      *
      * @var string
      */
@@ -345,8 +345,18 @@ class SassHandler extends CApplicationComponent
      */
     public function compile($sourcePath) {
         if ($this->autoAddCurrentDirectoryAsImportPath) {
+            // Theme sass
+            if ($theme = EO::app()->getTheme()) {
+            	if (!empty($theme->basePath)) {
+            		$this->compiler->addImportPath($theme->basePath);
+	            }
+            }
+
+        	// Project sass
             $this->compiler->addImportPath(dirname($sourcePath));
-//            $this->compiler->addImportPath(YiiBase::getPathOfAlias('@webroot'));
+
+            // Vendor sasss
+            $this->compiler->addImportPath(YiiBase::getPathOfAlias('vendor.digizijn'));
         }
 
         $sourceCode = file_get_contents($sourcePath);

--- a/SassHandler.php
+++ b/SassHandler.php
@@ -745,7 +745,7 @@ class SassHandler extends CApplicationComponent
     protected function cacheSet($name, $value)
     {
         if ($this->getCacheComponent()) {
-            return $this->getCacheComponent()->set($name, $value);
+            return $this->getCacheComponent()->set($name, $value, 604800);
         }
         $path = $this->getCachePathForName($name);
         if (!file_put_contents($path, serialize($value), LOCK_EX)) {

--- a/SassHandler.php
+++ b/SassHandler.php
@@ -311,9 +311,24 @@ class SassHandler extends CApplicationComponent
      * @throws CException
      * @return string
      */
-    public function getCompiledFile($sourcePath)
-    {
+    public function getCompiledFile($sourcePath) {
         $cssPath = $this->getCompiledCssFilePath($sourcePath);
+
+        if ($this->autoAddCurrentDirectoryAsImportPath) {
+            // Theme sass
+            if ($theme = EO::app()->getTheme()) {
+            	if (!empty($theme->basePath)) {
+            		$this->compiler->addImportPath($theme->basePath);
+	            }
+            }
+
+        	// Project sass
+            $this->compiler->addImportPath(dirname($sourcePath));
+
+            // Vendor sasss
+            $this->compiler->addImportPath(YiiBase::getPathOfAlias('vendor.digizijn'));
+        }
+
         if ($this->isCompilationNeeded($sourcePath)) {
             $compiledCssCode = $this->compile($sourcePath);
 
@@ -344,21 +359,6 @@ class SassHandler extends CApplicationComponent
      * @return string Compiled CSS code
      */
     public function compile($sourcePath) {
-        if ($this->autoAddCurrentDirectoryAsImportPath) {
-            // Theme sass
-            if ($theme = EO::app()->getTheme()) {
-            	if (!empty($theme->basePath)) {
-            		$this->compiler->addImportPath($theme->basePath);
-	            }
-            }
-
-        	// Project sass
-            $this->compiler->addImportPath(dirname($sourcePath));
-
-            // Vendor sasss
-            $this->compiler->addImportPath(YiiBase::getPathOfAlias('vendor.digizijn'));
-        }
-
         $sourceCode = file_get_contents($sourcePath);
         if ($sourceCode === false) {
             throw new CException(

--- a/SassHandler.php
+++ b/SassHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+use Padaliyajay\PHPAutoprefixer\Autoprefixer;
+
 /**
  * Sass Handler
  *
@@ -397,6 +399,8 @@ class SassHandler extends CApplicationComponent
         }
 
         $compiledCssCode = $this->compiler->compile($sourceCode);
+
+		$compiledCssCode 		= (new Autoprefixer($compiledCssCode))->compile();
 
         if ($this->autoAddCurrentDirectoryAsImportPath) {
             $this->compiler->setImportPaths($originalImportPaths);

--- a/SassHandler.php
+++ b/SassHandler.php
@@ -38,26 +38,6 @@ class SassHandler extends CApplicationComponent
     public $compilerPath;
 
     /**
-     * Path and filename of compass.inc.php
-     *
-     * Defaults to the relative location in Composer's vendor directory:
-     * __DIR__ . "/../../leafo/scssphp-compass/compass.inc.php"
-     *
-     * @var string
-     */
-    public $compassPath;
-
-    /**
-     * Enable Compass support.
-     * Automatically add required import paths and functions.
-     *
-     * Defaults to false
-     *
-     * @var boolean
-     */
-    public $enableCompass = false;
-
-    /**
      * Path to a directory with compiled CSS files.
      * Will be created automatically if it doesn't exist.
      * Will be chmod'ed to become writable, see "writableDirectoryPermissions"
@@ -209,11 +189,6 @@ class SassHandler extends CApplicationComponent
 
         if (!$this->compilerPath) {
             $this->compilerPath = $vendorPath . 'leafo/scssphp/scss.inc.php';
-        }
-
-        if (!$this->compassPath) {
-            $this->compassPath = $vendorPath
-                . "leafo/scssphp-compass/compass.inc.php";
         }
 
         parent::init();
@@ -424,12 +399,6 @@ class SassHandler extends CApplicationComponent
             require_once dirname(__FILE__) . '/ExtendedScssc.php';
             $this->scssc = new ExtendedScssc();
             $this->setImportPaths($this->importPaths);
-            if ($this->enableCompass) {
-                if (is_readable($this->compassPath)) {
-                    require_once $this->compassPath;
-                }
-                new scss_compass($this->scssc);
-            }
             $this->setupOutputFormatting($this->scssc);
         }
         return $this->scssc;
@@ -590,7 +559,6 @@ class SassHandler extends CApplicationComponent
             'compiledFiles' => $parsedFiles,
             'autoAddCurrentDirectoryAsImportPath'
                 => $this->autoAddCurrentDirectoryAsImportPath,
-            'enableCompass' => $this->enableCompass,
             'importPaths' => $this->compiler->getImportPaths(),
             'compilerOutputFormatting' => $this->compilerOutputFormatting,
         );
@@ -658,7 +626,6 @@ class SassHandler extends CApplicationComponent
 
         $fieldsToCheckForChangedValue = array(
             'autoAddCurrentDirectoryAsImportPath',
-            'enableCompass',
             'compilerOutputFormatting',
         );
         foreach ($fieldsToCheckForChangedValue as $field) {

--- a/SassHandler.php
+++ b/SassHandler.php
@@ -121,7 +121,7 @@ class SassHandler extends CApplicationComponent
      *
      * @var integer
      */
-    public $writableFilePermissions = 0666;
+    public $writableFilePermissions = 0776;
 
     /**
      * Default value for $hashByName parameter in extension's methods.
@@ -176,23 +176,9 @@ class SassHandler extends CApplicationComponent
     /**
      * Compiler object
      *
-     * @var ExtendedScssc
+     * @var Sass
      */
     protected $scssc;
-
-    /**
-     * Initialize component
-     */
-    public function init()
-    {
-        $vendorPath = __DIR__ . '/../../';
-
-        if (!$this->compilerPath) {
-            $this->compilerPath = $vendorPath . 'leafo/scssphp/scss.inc.php';
-        }
-
-        parent::init();
-    }
 
     /**
      * Publish and register compiled CSS file.
@@ -257,14 +243,12 @@ class SassHandler extends CApplicationComponent
     /**
      * Publish compiled CSS file.
      * Compile/recompile source SCSS file if needed.
-     *
      * Optionally can publish compiled CSS file inside
      * specific published directory.
      * It's helpful when CSS code has relative references to other
      * resources (images/fonts) and when these resources are also published
      * using Yii asset manager. This method allows to publish compiled CSS files
      * along with other resources to make relative references work.
-     *
      * E.g.:
      * "image.jpg" is stored inside path alias "application.files.images"
      * Somewhere in the code the following is called during page generation:
@@ -279,7 +263,6 @@ class SassHandler extends CApplicationComponent
      *     'application.files',
      *     'css_compiled'
      * );
-     *
      * @param string $sourcePath Path to the source SCSS file
      * @param string $insidePublishedDirectory Path to the directory
      *        with resource files which is published somewhere
@@ -294,6 +277,7 @@ class SassHandler extends CApplicationComponent
      *        See CAssetManager::publish() for details.
      *        "defaultHashByName" plugin parameter's value is used by default.
      * @return string URL of the published CSS file
+	 * @throws CException
      * @see CAssetManager::publish()
      */
     public function publish(
@@ -359,11 +343,10 @@ class SassHandler extends CApplicationComponent
      * @throws CException
      * @return string Compiled CSS code
      */
-    public function compile($sourcePath)
-    {
+    public function compile($sourcePath) {
         if ($this->autoAddCurrentDirectoryAsImportPath) {
-            $originalImportPaths = $this->compiler->getImportPaths();
             $this->compiler->addImportPath(dirname($sourcePath));
+//            $this->compiler->addImportPath(YiiBase::getPathOfAlias('@webroot'));
         }
 
         $sourceCode = file_get_contents($sourcePath);
@@ -373,12 +356,10 @@ class SassHandler extends CApplicationComponent
             );
         }
 
-        $compiledCssCode = $this->compiler->compile($sourceCode);
+        $compiledCssCode = $this->compiler->compile(ltrim($sourceCode));
 
-		$compiledCssCode 		= (new Autoprefixer($compiledCssCode))->compile();
-
-        if ($this->autoAddCurrentDirectoryAsImportPath) {
-            $this->compiler->setImportPaths($originalImportPaths);
+        if (!defined('YII_DEBUG') || !YII_DEBUG) {
+			$compiledCssCode 		= (new Autoprefixer($compiledCssCode))->compile();
         }
 
         return $compiledCssCode;
@@ -388,18 +369,31 @@ class SassHandler extends CApplicationComponent
      * Get compiler
      * Loads required files on initial request
      *
-     * @return ExtendedScssc
+     * @return Sass
      */
     public function getCompiler()
     {
         if (!$this->scssc) {
-            if (is_readable($this->compilerPath)) {
-                require_once $this->compilerPath;
-            }
-            require_once dirname(__FILE__) . '/ExtendedScssc.php';
             $this->scssc = new ExtendedScssc();
-            $this->setImportPaths($this->importPaths);
+
+            if (YII_DEBUG) {
+            	$this->scssc->setComments(true);
+                $this->scssc->setEmbed(true);
+            } else {
+            	$this->scssc->setComments(false);
+            	$this->scssc->setEmbed(false);
+            }
+
+	        if (!empty($this->importPaths)) {
+                $this->scssc->setImportPaths($this->importPaths); // FIXME callables
+	        }
+
             $this->setupOutputFormatting($this->scssc);
+
+            // setMapPath
+	        // setMapRoot
+	        // setImporter
+	        // setFunctions -> asset path functie maken?
         }
         return $this->scssc;
     }
@@ -492,24 +486,24 @@ class SassHandler extends CApplicationComponent
 
     /**
      * Setup compiler output formatting
-     * @param ExtendedScssc $compiler
+     * @param Sass $compiler
      * @throws CException
      */
-    protected function setupOutputFormatting($compiler)
-    {
-        $formatters = array(
-            self::OUTPUT_FORMATTING_NESTED
-                => 'ScssPhp\ScssPhp\Formatter\Nested',
-            self::OUTPUT_FORMATTING_COMPRESSED
-                => 'ScssPhp\ScssPhp\Formatter\Compressed',
-            self::OUTPUT_FORMATTING_EXPANDED
-                => 'ScssPhp\ScssPhp\Formatter\Expanded',
-            self::OUTPUT_FORMATTING_CRUNCHED
-                => 'ScssPhp\ScssPhp\Formatter\Crunched',
+    protected function setupOutputFormatting($compiler) {
+    	if (YII_DEBUG) {
+    		$compiler->setIndent(true);
+	    } else {
+    		$compiler->setIndent(true);
+	    }
+        $formatting = array(
+            self::OUTPUT_FORMATTING_NESTED      => Sass::STYLE_NESTED,
+            self::OUTPUT_FORMATTING_COMPRESSED  => Sass::STYLE_COMPRESSED,
+            self::OUTPUT_FORMATTING_EXPANDED    => Sass::STYLE_EXPANDED,
+            self::OUTPUT_FORMATTING_CRUNCHED    => Sass::STYLE_COMPACT,
         );
-        if (isset($formatters[$this->compilerOutputFormatting])) {
-            $compiler->setFormatter(
-                $formatters[$this->compilerOutputFormatting]
+        if (in_array($this->compilerOutputFormatting, array_keys($formatting))) {
+            $compiler->setStyle(
+                $formatting[$this->compilerOutputFormatting]
             );
         } else {
             throw new CException(
@@ -526,21 +520,8 @@ class SassHandler extends CApplicationComponent
      *
      * @param array|string $paths Single import path or a list of paths
      */
-    protected function setImportPaths($paths)
-    {
-        $paths = (array) $paths;
-        $preparedPaths = array();
-
-        foreach ($paths as $originalPath) {
-            $preparedPath = YiiBase::getPathOfAlias($originalPath);
-            if ($preparedPath !== false) {
-                $preparedPaths[] = $preparedPath;
-            } else {
-                $preparedPaths[] = $originalPath;
-            }
-        }
-
-        $this->scssc->setImportPaths($preparedPaths);
+    protected function setImportPaths($paths) {
+        return $this->scssc->addImportPaths((array)$paths);
     }
 
     /**
@@ -552,7 +533,7 @@ class SassHandler extends CApplicationComponent
      */
     protected function saveParsedFilesInfoToCache($sourcePath)
     {
-        $parsedFiles = $this->compiler->getParsedFiles();
+        $parsedFiles = $this->compiler->getParsedFiles(); // FIXME
         $parsedFiles[$sourcePath] = filemtime($sourcePath);
 
         $info = array(
@@ -649,14 +630,19 @@ class SassHandler extends CApplicationComponent
             return true;
         }
 
-        foreach ($compiledInfo['compiledFiles'] as
-                 $compiledFile => $previousModificationTime) {
-            if (filemtime($compiledFile) > $previousModificationTime) {
-                return true;
-            }
+        foreach ($compiledInfo['compiledFiles'] as $compiledFile => $previousModificationTime) {
+        	if (!empty($compiledFile)) {
+        		 if (substr($compiledFile, -5) !== '.scss') {
+        		 	$compiledFile .= '.scss';
+				 }
+
+				if (file_exists($compiledFile) && filemtime($compiledFile) > $previousModificationTime) {
+					return true;
+				}
+			}
         }
 
-        return false;
+        return $this->forceCompilation;
     }
 
     /**

--- a/SassHandler.php
+++ b/SassHandler.php
@@ -684,7 +684,7 @@ class SassHandler extends CApplicationComponent
 
         foreach ($compiledInfo['compiledFiles'] as
                  $compiledFile => $previousModificationTime) {
-            if (filemtime($compiledFile) != $previousModificationTime) {
+            if (filemtime($compiledFile) > $previousModificationTime) {
                 return true;
             }
         }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "leafo/scssphp": "^0.6",
+        "leafo/scssphp": "^0.8.4",
         "artem-frolov/scssphp-compass": "0.1.*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "leafo/scssphp": "^0.8.4",
+        "scssphp/scssphp": "^1.0.4",
         "artem-frolov/scssphp-compass": "0.1.*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
-        "scssphp/scssphp": "^1.0.4"
+        "php": ">=7.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.2",

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "artem-frolov/yii-sass",
     "type": "library",
-    "description": "Sass (SCSS) and Compass support for the Yii framework",
-    "keywords": ["yii","sass","compass","scss","css"],
+    "description": "Sass (SCSS) support for the Yii framework",
+    "keywords": ["yii","sass","scss","css"],
     "homepage": "https://github.com/artem-frolov/yii-sass",
     "license": "MIT",
     "authors": [
@@ -15,8 +15,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "scssphp/scssphp": "^1.0.4",
-        "artem-frolov/scssphp-compass": "0.1.*"
+        "scssphp/scssphp": "^1.0.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.2",

--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,14 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "leafo/scssphp": "~0.6.7",
+        "leafo/scssphp": "^0.6",
         "artem-frolov/scssphp-compass": "0.1.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.2",
+        "phpunit/phpunit": "^4.2",
         "phpmd/phpmd" : "*",
         "squizlabs/php_codesniffer": "*",
-        "yiisoft/yii": "~1.1",
+        "yiisoft/yii": "^1.1",
 	  	"padaliyajay/php-autoprefixer": "dev-master"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "phpunit/phpunit": "~4.2",
         "phpmd/phpmd" : "*",
         "squizlabs/php_codesniffer": "*",
-        "yiisoft/yii": "~1.1"
+        "yiisoft/yii": "~1.1",
+	  	"padaliyajay/php-autoprefixer": "dev-master"
     },
     "autoload": {
         "classmap": [

--- a/tests/SassHandlerTest.php
+++ b/tests/SassHandlerTest.php
@@ -43,20 +43,6 @@ class SassHandlerTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * Test integration with scssphp-compass library
-     */
-    public function testCompass()
-    {
-        $this->sassHandler->compassPath =
-            __DIR__ . '/../vendor/leafo/scssphp-compass/compass.inc.php';
-        $this->sassHandler->enableCompass = true;
-        $scssFile = $this->fixturesDirectory . 'compass.scss';
-        $this->assertEquals(
-            'div{filter:progid:DXImageTransform.Microsoft.Alpha(Opacity=10);opacity:0.1}',
-            $this->sassHandler->compile($scssFile)
-        );
-    }
 
     public function testGetCompiledFile()
     {

--- a/tests/fixtures/compass.scss
+++ b/tests/fixtures/compass.scss
@@ -1,5 +1,0 @@
-@import "compass/css3/opacity";
-
-div {
-  @include opacity(0.1);
-}


### PR DESCRIPTION
Compiler kept generating assets because of different theme(path)s with same source files.